### PR TITLE
Fix typo: Corrected 'assitant' to 'assistant'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# LiveKit-AI-Voice-Assitant
+# LiveKit-AI-Voice-Assistant
 
 # 💻 Launch Your Software Development Career Today!  
 

--- a/main.py
+++ b/main.py
@@ -20,7 +20,7 @@ async def entrypoint(ctx: JobContext):
     await ctx.connect(auto_subscribe=AutoSubscribe.AUDIO_ONLY)
     fnc_ctx = AssistantFnc()
 
-    assitant = VoiceAssistant(
+    assistant = VoiceAssistant(
         vad=silero.VAD.load(),
         stt=openai.STT(),
         llm=openai.LLM(),
@@ -28,10 +28,10 @@ async def entrypoint(ctx: JobContext):
         chat_ctx=initial_ctx,
         fnc_ctx=fnc_ctx,
     )
-    assitant.start(ctx.room)
+    assistant.start(ctx.room)
 
     await asyncio.sleep(1)
-    await assitant.say("Hey, how can I help you today!", allow_interruptions=True)
+    await assistant.say("Hey, how can I help you today!", allow_interruptions=True)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR fixes a typographical error in the variable name from `assitant `to `assistant `in the `entrypoint` function and the README file.
Resolves  #2